### PR TITLE
Fixed paid post if statement

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -120,7 +120,7 @@ into the {body} of the default.hbs template --}}
                     </div>
                     <aside class="post-upgrade-cta">
                         <div class="post-upgrade-cta-content">
-                            {{#if @member}}
+                            {{#if @labs.members}}
                             <h2>This post is for paying subscribers only</h2>
                             {{else}}
                             <h2>This post is for subscribers only</h2>


### PR DESCRIPTION
Instead of saying "This post is for subscribers only" when the post is paid, it now correctly says "This post is for paying subscribers only".

Tested on 3.0 local Ghost installation.

Maybe a recurring issue throughout the theme?