### PR TITLE
Used {{price}} on account page

### DIFF
--- a/members/account.hbs
+++ b/members/account.hbs
@@ -31,7 +31,7 @@
 
                         <div class="subscriber-detail">
                             <label class="subscriber-detail-label">Your plan</label>
-                            <span class="subscriber-detail-content">$<span class="plan-price">0</span>/{{plan.interval}}</span>
+                            <span class="subscriber-detail-content">${{price plan.amount}}/{{plan.interval}}</span>
                         </div>
 
                         <div class="subscriber-detail">
@@ -49,15 +49,6 @@
                             </label>
                             <span class="subscriber-detail-content">{{date current_period_end format="DD MMM YYYY"}}</span>
                         </div>
-
-                        {{#contentFor "scripts"}}
-                        <script>
-                            $(document).ready(function () {
-                                var planAmount = {{ plan.amount }} / 100;
-                                $(".plan-price").html(planAmount);
-                            });
-                        </script>
-                        {{/contentFor}}
                     </div>
 
                     {{cancel_link}}


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/11473

- Removes a JS hack from account page used for currency formatting

**Note**: we need to add a version tag and Ghost version compatibility information when this is merged into master aka "cut a release". It's gonna get very hard to track the compatibility of the theme otherwise. The helper itself will be available starting with `3.3.0` release.