### PR TITLE
Don't use menu ARIA roles in site navigation.

### DIFF
--- a/partials/navigation.hbs
+++ b/partials/navigation.hbs
@@ -5,9 +5,9 @@
         {{/foreach}}
 {{else}}
     {{!-- primary navigation --}}
-    <ul class="nav" role="menu">
+    <ul class="nav">
         {{#foreach navigation}}
-            <li class="{{link_class for=(url) class=(concat "nav-" slug)}}" role="menuitem"><a href="{{url absolute="true"}}">{{label}}</a></li>
+            <li class="{{link_class for=(url) class=(concat "nav-" slug)}}"><a href="{{url absolute="true"}}">{{label}}</a></li>
         {{/foreach}}
     </ul>
 {{/if}}


### PR DESCRIPTION
1. These were inconsistently applied, and weren't used on all nav items. I.e. the navigationsite navigation items had them, but not the login/signup links.
2. They're only intended for things that behave like menubars/dropdown menus (I.e. are navigable by up/down arrows, as commonly found in applications.)

As a screen reader user myself, this ARIA markup actually made the navbars *less* accessible, so I've removed them in my own site. But I'd suggest that this be merged, as it is an incorrect use of these roles.