### PR TITLE
fix jquery initialization bug

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -90,7 +90,7 @@
         var action = getParameterByName('action');
         var stripe = getParameterByName('stripe');
 
-        $(document).ready(function () {
+        jQuery(document).ready(function ($) {
             if (action == 'subscribe') {
                 $('body').addClass("subscribe-success");
             }


### PR DESCRIPTION
This fixes an issue where the jQuery shorthand, `$`, is `undefined` causing the functions within `default.hbs` to fail.

![Screen Shot 2020-08-29 at 3 40 07 PM](https://user-images.githubusercontent.com/17229444/91644901-76b16380-ea0e-11ea-83fa-7004aaee6c74.png)
