### PR TITLE
Gulp > Add postship

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ projectFilesBackup
 .DS_Store
 
 dist/
+
+config.json
+changelog.md
+changelog.md.bk

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,5 @@
+{
+    "github": {
+        "token": "<gh-personal-access-token>"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "test:ci": "gscan --fatal --verbose .",
         "pretest": "gulp build",
         "preship": "yarn test",
-        "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn version && git push --follow-tags; fi"
+        "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn version && git push --follow-tags; else echo \"Uncomitted changes found.\" && exit 1; fi",
+        "postship": "git fetch && gulp release"
     },
     "author": {
         "name": "Ghost Foundation",


### PR DESCRIPTION
Add **postship** task from Casper, it will:
- added gulp task to extend Lyra release automation
- will draft the release for you
- will get the user facing commits from changelog
- runs after `yarn ship` (postship)
- full automation with env variables is possible