### PR TITLE
Remove "ghost-api" version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
     "demo": "https://lyra.ghost.io",
     "version": "1.0.0",
     "engines": {
-        "ghost": ">=4.0.0",
-        "ghost-api": "v4"
+        "ghost": ">=4.0.0"
     },
     "license": "MIT",
     "screenshots": {


### PR DESCRIPTION
Gscan throws a warning as this is no longer needed, so removing as part of standard maintenance.